### PR TITLE
Fixes for PCS

### DIFF
--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -24,7 +24,7 @@
 
 # Set the variable below to '1' to enable zpool import/export logging.
 # This is useful to determine how long these operations take on your system.
-# DEBUG=0
+DEBUG=0
 DEBUGLOG="/var/log/ZFS_cluster_debug.log"
 
 USAGE="usage: $0 {start|stop|status|monitor|validate-all|meta-data}";
@@ -79,7 +79,7 @@ END
 }
 
 zpool_is_imported () {
-    zpool list -H "$OCF_RESKEY_pool" > /dev/null
+    zpool list -H "$OCF_RESKEY_pool" > /dev/null 2>/dev/null
 }
 
 # Forcibly imports a ZFS pool, mounting all of its auto-mounted filesystems


### PR DESCRIPTION
If the DEBUG variable is not set, line 35 fails with incorrect comparison. It has to be either '0' or '1' (or any integer value)
zpool_is_imported failure (because it is not imported initially) results in OCF_STD_ERR which results in error messages of the resource in PCS, despite loading and mounting.